### PR TITLE
Fix setTime and submission time window issue

### DIFF
--- a/src/main/java/com/digitalasset/testing/ledger/clock/SandboxTimeProvider.java
+++ b/src/main/java/com/digitalasset/testing/ledger/clock/SandboxTimeProvider.java
@@ -53,7 +53,7 @@ public class SandboxTimeProvider implements TimeProvider {
           });
 
       p.waitForTimeChange(Instant.EPOCH);
-      logger.warn("SandboxTimeProvider started");
+      logger.info("SandboxTimeProvider started");
       return p;
     };
   }

--- a/src/test/resources/ping-pong/daml/PingPong.daml
+++ b/src/test/resources/ping-pong/daml/PingPong.daml
@@ -29,3 +29,21 @@ template Pong
     controller receiver can
       RespondPing : ContractId Ping
         do create Ping with sender = receiver; receiver = sender; count = count + 1
+
+
+template TimedPing
+  with
+    expectedAfter: Time
+    sender: Party
+    receiver: Party
+    count: Int
+  where
+    signatory sender
+    observer receiver
+
+    controller receiver can
+      TimedPingRespondPong : ContractId Pong
+        do
+          now <- getTime
+          assertMsg ("TimedPingRespondPong should be called after " <> show expectedAfter) $ expectedAfter < now
+          create Pong with sender = receiver; receiver = sender; count = count + 1


### PR DESCRIPTION
Solves #7 
After calling `setCurrentTime`, we need to wait for actual time (an atomic reference in the same class, `SandboxTimeProvider`) to update itself via the time observer. Before, this logic was not there which caused in some cases that an exercise command following a `setCurrentTime` operation could potentially fail (submission time violated the corresponding time rules, it was "out if time window").

This PR solves the issue by waiting for an actualized "actual time" value (with Guava Monitor).