### PR TITLE
ERA-509 Expose port sandbox port in test library

### DIFF
--- a/src/main/java/com/digitalasset/testing/junit4/Sandbox.java
+++ b/src/main/java/com/digitalasset/testing/junit4/Sandbox.java
@@ -160,6 +160,10 @@ public class Sandbox {
     return sandboxManager.getLedgerAdapter();
   }
 
+  public int getSandboxPort() {
+    return sandboxManager.getPort();
+  }
+
   public Identifier templateIdentifier(
       DamlLf1.DottedName packageName, String moduleName, String entityName)
       throws InvalidProtocolBufferException {

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
@@ -18,7 +18,7 @@ public class SandboxTest {
   @Rule public ExternalResource rule = sandbox.getRule();
 
   @Test
-  public void getSandboxPort() {
+  public void portIsAssignedWhenSandboxIsStarted() {
     int sandboxPort = sandbox.getSandboxPort();
     assertAreBetween(sandboxPort, 6860, 6890);
   }

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
@@ -1,0 +1,30 @@
+package com.digitalasset.testing.junit4;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+import java.nio.file.Paths;
+
+public class SandboxTest {
+
+  private static Sandbox sandbox =
+      Sandbox.builder().dar(Paths.get("./src/test/resources/ping-pong.dar")).build();
+
+  @ClassRule public static ExternalResource classRule = sandbox.getClassRule();
+
+  @Rule public ExternalResource rule = sandbox.getRule();
+
+  @Test
+  public void getSandboxPort() {
+    int sandboxPort = sandbox.getSandboxPort();
+    assertAreBetween(sandboxPort, 6860, 6890);
+  }
+
+  private void assertAreBetween(int x, int low, int high) {
+    String message = String.format("Expected '%d' to be between '%d' and '%d'", x, low, high);
+    Assert.assertTrue(message, low <= x && x <= high);
+  }
+}

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
@@ -20,7 +20,7 @@ public class SandboxTest {
   @Test
   public void portIsAssignedWhenSandboxIsStarted() {
     int sandboxPort = sandbox.getSandboxPort();
-    assertAreBetween(sandboxPort, 6860, 6890);
+    assertsIsBetween(sandboxPort, 6860, 6890);
   }
 
   private void assertsIsBetween(int x, int low, int high) {

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxTest.java
@@ -23,7 +23,7 @@ public class SandboxTest {
     assertAreBetween(sandboxPort, 6860, 6890);
   }
 
-  private void assertAreBetween(int x, int low, int high) {
+  private void assertsIsBetween(int x, int low, int high) {
     String message = String.format("Expected '%d' to be between '%d' and '%d'", x, low, high);
     Assert.assertTrue(message, low <= x && x <= high);
   }


### PR DESCRIPTION
This PR exposes the port of the sandbox. That proved to be useful in certain situations, for instance when one wants to test a DAML trigger.