### PR TITLE
Upgrade to SDK 0.13.56-snapshot.20200325.3626.0.a3ddde3a

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val DAML_SDK_VERSION = "100.13.52"
+  val DAML_SDK_VERSION = "100.13.56-snapshot.20200325.3626.0.a3ddde3a"
   val scalapbVersion = "0.9.2"
   val yamlVersion = "1.23"
   val cucumberVersion = "4.3.1"

--- a/src/main/java/com/digitalasset/testing/ledger/DefaultLedgerAdapter.java
+++ b/src/main/java/com/digitalasset/testing/ledger/DefaultLedgerAdapter.java
@@ -227,8 +227,6 @@ public class DefaultLedgerAdapter {
   }
 
   private void submit(Party party, Command command) {
-    Instant let = timeProvider.getCurrentTime();
-    Instant mrt = let.plus(TTL);
     String cmdId = UUID.randomUUID().toString();
 
     CommandServiceOuterClass.SubmitAndWaitRequest.Builder commands =
@@ -240,8 +238,6 @@ public class DefaultLedgerAdapter {
                     .setApplicationId(APP_ID)
                     .setCommandId(cmdId)
                     .setParty(party.getValue())
-                    .setLedgerEffectiveTime(toProtobufTimestamp(let))
-                    .setMaximumRecordTime(toProtobufTimestamp(mrt))
                     .addCommands(command.toProtoCommand()));
     CommandEvent event = new CommandEvent(cmdId, party.getValue(), command);
     Dump.dump(wireLogger, event);

--- a/src/test/resources/ping-pong/daml.yaml
+++ b/src/test/resources/ping-pong/daml.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-sdk-version: 0.13.52
+sdk-version: 0.13.56-snapshot.20200325.3626.0.a3ddde3a
 name: ping-pong
 source: daml/Test.daml
 scenario: testSetup


### PR DESCRIPTION
This updates to the latest SDK snapshot SDK `0.13.56-snapshot.20200325.3626.0.a3ddde3a`, removing usage of LET and MRT.