### PR TITLE
Fixes DEL-8238

### DIFF
--- a/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
+++ b/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
@@ -83,7 +83,7 @@ package object ledger {
         Diff(s"$path: Expected to be null, but actual value is: $actual")
   
       case (_, Ast.Null) => 
-        Diff(s"$path: Value is null, but was expected to be $expected")
+        Diff(s"$path: Value is null, but was expected to be: $expected")
 
       case _ =>
         Error(s"$path: Unexpected or unsupported case: $expected, $actual")

--- a/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
+++ b/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
@@ -78,6 +78,12 @@ package object ledger {
 
       case (Ast.Null, Ast.Null) =>
         Same()
+      
+      case (Ast.Null, _) => 
+        Diff(s"$path: Expected to be null, but actual value is: $actual")
+  
+      case (_, Ast.Null) => 
+        Diff(s"$path: Value is null, but was expected to be $expected")
 
       case _ =>
         Error(s"$path: Unexpected or unsupported case: $expected, $actual")


### PR DESCRIPTION
Currently if only one of the expected or actual values are nulls the case falls back to the catch-all case, and will err out.

This means func-tests will only show the first of such fields as being incorrect, and they need to be rerun and fixed one-by-one.