### PR TITLE
Functionality to enable the JUnit rule to download the DAR and daml.yaml files from a maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Additional daml dependencies are required by the library, but these dependencies
 ### Using the library with the Sandbox JUnit4 Rule
 
 One can easily instantiate a Sandbox process using the JUnit4 Rule technique:
-```
+```java
   private static Sandbox sandbox =
       Sandbox.builder()
           .dar(DAR_PATH)
@@ -59,6 +59,37 @@ Sandbox has two modes, restart mode, in which it is restarted after each test ca
 Sandbox object `sandbox` offers the following tools:
 - a ledger adapter via `getLedgerAdapter` (which has the type *DefaultLedgerAdapter*)
 - a DAML ledger client via `getClient`
+
+#### Pulling the DAR file and daml.yaml files from a Maven repository
+
+It is possible to pull the DAR file and optionally the daml.yaml file from a Maven repository if your CI/CD 
+pipelines are publishing such artifacts.
+
+```java
+      Sandbox.builder()
+            .darMavenCoordinates(MavenCoordinates.builder()
+                    .repoUrl("https://repo.host/path/to/maven/repo")
+                    .group("name_of_maven_group")
+                    .darArtifact("name_of_dar_artifact")
+                    .yamlArtifact("name_of_yaml_artifact")
+                    .version("x.y.x")
+                    .mavenCredentials(MavenCredentials.builder()
+                            .userName("mavenUserName")
+                            .password("mavenPwd")
+                            .build())
+                    .build())
+            .moduleAndScript("Test", "testSetup")
+            .parties(ALICE, BOB, CHARLIE)
+            .build();
+```
+
+The advantage of doing it is that you won't have to manually copy the DAR file and store it in your source control repo.
+Moreover, if you use features in your build system to inject the version of your generated bindings in your test code
+using environment variables or VM parameters, you can make sure you're always testing against a DAR file that matches 
+your bindings.  
+
+
+The advantage of doing it is that you won't have to manually copy the DAR file and store it in your source control repo. 
 
 ### Testing with functions provided by a ledger adapter
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,14 @@ libraryDependencies ++= Seq(
   hamcrestOptional,
   cucumberJ8,
   cucumberJunit,
-  cucumberPicoContainer
+  cucumberPicoContainer,
+  aether1,
+  aether2,
+  aether3,
+  aether4,
+  aether5,
+  aether6,
+  aether7
 )
 
 scalaVersion := "2.12.8"

--- a/build.sbt
+++ b/build.sbt
@@ -51,13 +51,13 @@ libraryDependencies ++= Seq(
   cucumberJ8,
   cucumberJunit,
   cucumberPicoContainer,
-  aether1,
-  aether2,
-  aether3,
-  aether4,
-  aether5,
-  aether6,
-  aether7
+  aetherApi,
+  aetherSpi,
+  aetherImpl,
+  aetherConnectorBasic,
+  aetherTransportFile,
+  aetherTransportHttp,
+  mavenAetherProvider
 )
 
 scalaVersion := "2.12.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,15 @@ object Dependencies {
   lazy val snakeYaml = "org.yaml" % "snakeyaml" % yamlVersion
   lazy val hamcrestOptional = "com.spotify" % "hamcrest-optional" % "1.1.4"
 
+  lazy val aether1 = "org.eclipse.aether" % "aether-api" % "1.1.0"
+  lazy val aether2 = "org.eclipse.aether" % "aether-spi" % "1.1.0"
+  lazy val aether3 = "org.eclipse.aether" % "aether-impl" % "1.1.0"
+  lazy val aether4 = "org.eclipse.aether" % "aether-connector-basic" % "1.1.0"
+  lazy val aether5 = "org.eclipse.aether" % "aether-transport-file" % "1.1.0"
+  lazy val aether6 = "org.eclipse.aether" % "aether-transport-http" % "1.1.0"
+  lazy val aether7 = "org.apache.maven" % "maven-aether-provider" % "3.3.9"
+
+
   lazy val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.24"
   lazy val guava = "com.google.guava" % "guava" % "28.0-jre"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,13 +17,13 @@ object Dependencies {
   lazy val snakeYaml = "org.yaml" % "snakeyaml" % yamlVersion
   lazy val hamcrestOptional = "com.spotify" % "hamcrest-optional" % "1.1.4"
 
-  lazy val aether1 = "org.eclipse.aether" % "aether-api" % "1.1.0"
-  lazy val aether2 = "org.eclipse.aether" % "aether-spi" % "1.1.0"
-  lazy val aether3 = "org.eclipse.aether" % "aether-impl" % "1.1.0"
-  lazy val aether4 = "org.eclipse.aether" % "aether-connector-basic" % "1.1.0"
-  lazy val aether5 = "org.eclipse.aether" % "aether-transport-file" % "1.1.0"
-  lazy val aether6 = "org.eclipse.aether" % "aether-transport-http" % "1.1.0"
-  lazy val aether7 = "org.apache.maven" % "maven-aether-provider" % "3.3.9"
+  lazy val aetherApi = "org.eclipse.aether" % "aether-api" % "1.1.0"
+  lazy val aetherSpi = "org.eclipse.aether" % "aether-spi" % "1.1.0"
+  lazy val aetherImpl = "org.eclipse.aether" % "aether-impl" % "1.1.0"
+  lazy val aetherConnectorBasic = "org.eclipse.aether" % "aether-connector-basic" % "1.1.0"
+  lazy val aetherTransportFile = "org.eclipse.aether" % "aether-transport-file" % "1.1.0"
+  lazy val aetherTransportHttp = "org.eclipse.aether" % "aether-transport-http" % "1.1.0"
+  lazy val mavenAetherProvider = "org.apache.maven" % "maven-aether-provider" % "3.3.9"
 
 
   lazy val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.24"

--- a/src/main/java/com/digitalasset/testing/junit4/MavenCoordinates.java
+++ b/src/main/java/com/digitalasset/testing/junit4/MavenCoordinates.java
@@ -60,9 +60,9 @@ public class MavenCoordinates {
     private String repoUrl;
     private String group;
     private String darArtifact;
-    private Optional<String> yamlArtifact;
+    private Optional<String> yamlArtifact = Optional.empty();
     private String version;
-    private Optional<MavenCredentials> mavenCredentials;
+    private Optional<MavenCredentials> mavenCredentials = Optional.empty();
 
     private Builder() {}
 

--- a/src/main/java/com/digitalasset/testing/junit4/MavenCoordinates.java
+++ b/src/main/java/com/digitalasset/testing/junit4/MavenCoordinates.java
@@ -1,0 +1,116 @@
+package com.digitalasset.testing.junit4;
+
+import com.digitalasset.testing.utils.Preconditions;
+import com.google.common.base.Strings;
+
+import java.util.Optional;
+
+public class MavenCoordinates {
+  private final String repoUrl;
+  private final String group;
+  private final String darArtifact;
+  private final Optional<String> yamlArtifact;
+  private final String version;
+  private Optional<MavenCredentials> mavenCredentials;
+
+  private MavenCoordinates(
+      String repoUrl,
+      String group,
+      String darArtifact,
+      Optional<String> yamlArtifact,
+      String version,
+      Optional<MavenCredentials> mavenCredentials) {
+    this.repoUrl = repoUrl;
+    this.group = group;
+    this.darArtifact = darArtifact;
+    this.yamlArtifact = yamlArtifact;
+    this.version = version;
+    this.mavenCredentials = mavenCredentials;
+  }
+
+  public String getRepoUrl() {
+    return repoUrl;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getDarArtifact() {
+    return darArtifact;
+  }
+
+  public Optional<String> getYamlArtifact() {
+    return yamlArtifact;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public Optional<MavenCredentials> getMavenCredentials() {
+    return mavenCredentials;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String repoUrl;
+    private String group;
+    private String darArtifact;
+    private Optional<String> yamlArtifact;
+    private String version;
+    private Optional<MavenCredentials> mavenCredentials;
+
+    private Builder() {}
+
+    public Builder repoUrl(String repoUrl) {
+      this.repoUrl = repoUrl;
+      return this;
+    }
+
+    public Builder group(String group) {
+      this.group = group;
+      return this;
+    }
+
+    public Builder darArtifact(String darArtifact) {
+      this.darArtifact = darArtifact;
+      return this;
+    }
+
+    public Builder yamlArtifact(String yamlArtifact) {
+      this.yamlArtifact = Optional.ofNullable(yamlArtifact);
+      return this;
+    }
+
+    public Builder mavenCredentials(MavenCredentials mavenCredentials) {
+      this.mavenCredentials = Optional.ofNullable(mavenCredentials);
+      return this;
+    }
+
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    public MavenCoordinates build() {
+      Preconditions.require(
+          !Strings.isNullOrEmpty(repoUrl),
+          "a repository URL is required when building DAR maven coordinates");
+      Preconditions.require(
+          !Strings.isNullOrEmpty(group),
+          "a maven group hosting the DAR file is required when building DAR maven coordinates");
+      Preconditions.require(
+          !Strings.isNullOrEmpty(darArtifact),
+          "a maven artifact pointing to the DAR file is required when building DAR maven coordinates");
+      Preconditions.require(
+          !Strings.isNullOrEmpty(version),
+          "a version is required when building DAR maven coordinates");
+      return new MavenCoordinates(
+          repoUrl, group, darArtifact, yamlArtifact, version, mavenCredentials);
+    }
+  }
+}

--- a/src/main/java/com/digitalasset/testing/junit4/MavenCredentials.java
+++ b/src/main/java/com/digitalasset/testing/junit4/MavenCredentials.java
@@ -1,0 +1,53 @@
+package com.digitalasset.testing.junit4;
+
+import com.digitalasset.testing.utils.Preconditions;
+import com.google.common.base.Strings;
+
+public class MavenCredentials {
+  private final String userName;
+  private final String password;
+
+  private MavenCredentials(String userName, String password) {
+    this.userName = userName;
+    this.password = password;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String userName;
+    private String password;
+
+    private Builder() {}
+
+    public Builder userName(String userName) {
+      this.userName = userName;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public MavenCredentials build() {
+      Preconditions.require(
+          !Strings.isNullOrEmpty(userName),
+          "a user name is required when building maven credentials");
+      Preconditions.require(
+          !Strings.isNullOrEmpty(password),
+          "a password is required when building maven credentials");
+      return new MavenCredentials(userName, password);
+    }
+  }
+}

--- a/src/main/java/com/digitalasset/testing/junit4/MavenDownloader.java
+++ b/src/main/java/com/digitalasset/testing/junit4/MavenDownloader.java
@@ -27,108 +27,112 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 
 public class MavenDownloader {
-    protected static final String MAVEN_REPO_TYPE_DEFAULT = "default";
-    protected static final String DAML_REPO_ID = "DAML_REPO";
+  protected static final String MAVEN_REPO_TYPE_DEFAULT = "default";
+  protected static final String DAML_REPO_ID = "DAML_REPO";
 
-    public static Optional<File> downloadDarFileFromMaven(
-            MavenCoordinates mavenCoordinates, File localRepository) {
-        return downloadMavenArtifact(
-                mavenCoordinates.getGroup(),
-                mavenCoordinates.getDarArtifact(),
-                mavenCoordinates.getVersion(),
-                "dar",
-                mavenCoordinates.getRepoUrl(),
-                mavenCoordinates.getMavenCredentials(),
-                localRepository);
+  public static Optional<File> downloadDarFileFromMaven(
+      MavenCoordinates mavenCoordinates, File localRepository) {
+    return downloadMavenArtifact(
+        mavenCoordinates.getGroup(),
+        mavenCoordinates.getDarArtifact(),
+        mavenCoordinates.getVersion(),
+        "dar",
+        mavenCoordinates.getRepoUrl(),
+        mavenCoordinates.getMavenCredentials(),
+        localRepository);
+  }
+
+  public static Optional<File> downloadDamlYamlFileFromMaven(
+      MavenCoordinates mavenCoordinates, File localRepository) {
+    return mavenCoordinates
+        .getYamlArtifact()
+        .flatMap(
+            yamlArtifact ->
+                downloadMavenArtifact(
+                    mavenCoordinates.getGroup(),
+                    yamlArtifact,
+                    mavenCoordinates.getVersion(),
+                    "yaml",
+                    mavenCoordinates.getRepoUrl(),
+                    mavenCoordinates.getMavenCredentials(),
+                    localRepository))
+        .map(
+            file -> {
+              final File tempDamlRoot = createTempDamlRoot();
+              try {
+                Files.copy(file, new File(tempDamlRoot, "daml.yaml"));
+                return tempDamlRoot;
+              } catch (IOException e) {
+                throw new IllegalStateException(
+                    "Cannot copy DAML yaml file to temporary DAML root: "
+                        + tempDamlRoot.getAbsolutePath(),
+                    e);
+              }
+            });
+  }
+
+  private static File createTempDamlRoot() {
+    return Optional.of(Files.createTempDir())
+        .map(
+            f -> {
+              final File damlroot = new File(f, "damlroot");
+              if (damlroot.mkdirs()) return damlroot;
+              else
+                throw new IllegalStateException(
+                    "Unable to create temporary DAML root: " + damlroot.getAbsolutePath());
+            })
+        .get();
+  }
+
+  public static Optional<File> downloadMavenArtifact(
+      String groupId,
+      String artifactId,
+      String version,
+      String extension,
+      String mavenRepoUrl,
+      Optional<MavenCredentials> mavenCredentials,
+      File localRepository) {
+    RemoteRepository remoteRepository =
+        mavenCredentials
+            .map(
+                credentials ->
+                    new RemoteRepository.Builder(
+                            DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
+                        .setAuthentication(buildMavenAuthentication(credentials))
+                        .build())
+            .orElse(
+                new RemoteRepository.Builder(DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
+                    .build());
+
+    ArtifactRequest artifactRequest =
+        new ArtifactRequest()
+            .setArtifact(new DefaultArtifact(groupId, artifactId, extension, version))
+            .setRepositories(singletonList(remoteRepository));
+
+    try {
+      RepositorySystem repositorySystem =
+          MavenRepositorySystemUtils.newServiceLocator()
+              .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
+              .addService(TransporterFactory.class, FileTransporterFactory.class)
+              .addService(TransporterFactory.class, HttpTransporterFactory.class)
+              .getService(RepositorySystem.class);
+
+      DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+      session.setLocalRepositoryManager(
+          repositorySystem.newLocalRepositoryManager(
+              session, new LocalRepository(localRepository.toString())));
+      ArtifactResult artifactResult = repositorySystem.resolveArtifact(session, artifactRequest);
+      return Optional.ofNullable(artifactResult.getArtifact().getFile());
+    } catch (ArtifactResolutionException e) {
+      throw new IllegalStateException(
+          "Unable to download artifact " + groupId + ":" + artifactId + ":" + version, e);
     }
+  }
 
-    public static Optional<File> downloadDamlYamlFileFromMaven(
-            MavenCoordinates mavenCoordinates, File localRepository) {
-        return mavenCoordinates
-                .getYamlArtifact()
-                .flatMap(
-                        yamlArtifact ->
-                                downloadMavenArtifact(
-                                        mavenCoordinates.getGroup(),
-                                        yamlArtifact,
-                                        mavenCoordinates.getVersion(),
-                                        "yaml",
-                                        mavenCoordinates.getRepoUrl(),
-                                        mavenCoordinates.getMavenCredentials(),
-                                        localRepository))
-                .map(file -> {
-                    final File tempDamlRoot = createTempDamlRoot();
-                    try {
-                        Files.copy(file, new File(tempDamlRoot, "daml.yaml"));
-                        return tempDamlRoot;
-                    } catch (IOException e) {
-                        throw new IllegalStateException("Cannot copy DAML yaml file to temporary DAML root: " + tempDamlRoot.getAbsolutePath(), e);
-                    }
-                });
-    }
-
-    private static File createTempDamlRoot() {
-        return Optional.of(Files.createTempDir())
-                .map(f -> {
-                    final File damlroot = new File(f, "damlroot");
-                    if (damlroot.mkdirs())
-                        return damlroot;
-                    else
-                        throw new IllegalStateException("Unable to create temporary DAML root: " + damlroot.getAbsolutePath());
-                }).get();
-
-    }
-
-    public static Optional<File> downloadMavenArtifact(
-            String groupId,
-            String artifactId,
-            String version,
-            String extension,
-            String mavenRepoUrl,
-            Optional<MavenCredentials> mavenCredentials,
-            File localRepository) {
-        RemoteRepository remoteRepository =
-                mavenCredentials
-                        .map(
-                                credentials ->
-                                        new RemoteRepository.Builder(
-                                                DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
-                                                .setAuthentication(buildMavenAuthentication(credentials))
-                                                .build())
-                        .orElse(
-                                new RemoteRepository.Builder(DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
-                                        .build());
-
-        ArtifactRequest artifactRequest =
-                new ArtifactRequest()
-                        .setArtifact(new DefaultArtifact(groupId, artifactId, extension, version))
-                        .setRepositories(singletonList(remoteRepository));
-
-        try {
-            RepositorySystem repositorySystem =
-                    MavenRepositorySystemUtils.newServiceLocator()
-                            .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
-                            .addService(TransporterFactory.class, FileTransporterFactory.class)
-                            .addService(TransporterFactory.class, HttpTransporterFactory.class)
-                            .getService(RepositorySystem.class);
-
-            DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
-            session.setLocalRepositoryManager(
-                    repositorySystem.newLocalRepositoryManager(
-                            session, new LocalRepository(localRepository.toString())));
-            ArtifactResult artifactResult = repositorySystem.resolveArtifact(session, artifactRequest);
-            return Optional.ofNullable(artifactResult.getArtifact().getFile());
-        } catch (ArtifactResolutionException e) {
-            throw new IllegalStateException(
-                    "Unable to download artifact " + groupId + ":" + artifactId + ":" + version, e);
-        }
-    }
-
-    private static Authentication buildMavenAuthentication(MavenCredentials credentials) {
-        return new AuthenticationBuilder()
-                .addUsername(credentials.getUserName())
-                .addPassword(credentials.getPassword())
-                .build();
-    }
-
+  private static Authentication buildMavenAuthentication(MavenCredentials credentials) {
+    return new AuthenticationBuilder()
+        .addUsername(credentials.getUserName())
+        .addPassword(credentials.getPassword())
+        .build();
+  }
 }

--- a/src/main/java/com/digitalasset/testing/junit4/MavenDownloader.java
+++ b/src/main/java/com/digitalasset/testing/junit4/MavenDownloader.java
@@ -1,0 +1,134 @@
+package com.digitalasset.testing.junit4;
+
+import com.google.common.io.Files;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+
+public class MavenDownloader {
+    protected static final String MAVEN_REPO_TYPE_DEFAULT = "default";
+    protected static final String DAML_REPO_ID = "DAML_REPO";
+
+    public static Optional<File> downloadDarFileFromMaven(
+            MavenCoordinates mavenCoordinates, File localRepository) {
+        return downloadMavenArtifact(
+                mavenCoordinates.getGroup(),
+                mavenCoordinates.getDarArtifact(),
+                mavenCoordinates.getVersion(),
+                "dar",
+                mavenCoordinates.getRepoUrl(),
+                mavenCoordinates.getMavenCredentials(),
+                localRepository);
+    }
+
+    public static Optional<File> downloadDamlYamlFileFromMaven(
+            MavenCoordinates mavenCoordinates, File localRepository) {
+        return mavenCoordinates
+                .getYamlArtifact()
+                .flatMap(
+                        yamlArtifact ->
+                                downloadMavenArtifact(
+                                        mavenCoordinates.getGroup(),
+                                        yamlArtifact,
+                                        mavenCoordinates.getVersion(),
+                                        "yaml",
+                                        mavenCoordinates.getRepoUrl(),
+                                        mavenCoordinates.getMavenCredentials(),
+                                        localRepository))
+                .map(file -> {
+                    final File tempDamlRoot = createTempDamlRoot();
+                    try {
+                        Files.copy(file, new File(tempDamlRoot, "daml.yaml"));
+                        return tempDamlRoot;
+                    } catch (IOException e) {
+                        throw new IllegalStateException("Cannot copy DAML yaml file to temporary DAML root: " + tempDamlRoot.getAbsolutePath(), e);
+                    }
+                });
+    }
+
+    private static File createTempDamlRoot() {
+        return Optional.of(Files.createTempDir())
+                .map(f -> {
+                    final File damlroot = new File(f, "damlroot");
+                    if (damlroot.mkdirs())
+                        return damlroot;
+                    else
+                        throw new IllegalStateException("Unable to create temporary DAML root: " + damlroot.getAbsolutePath());
+                }).get();
+
+    }
+
+    public static Optional<File> downloadMavenArtifact(
+            String groupId,
+            String artifactId,
+            String version,
+            String extension,
+            String mavenRepoUrl,
+            Optional<MavenCredentials> mavenCredentials,
+            File localRepository) {
+        RemoteRepository remoteRepository =
+                mavenCredentials
+                        .map(
+                                credentials ->
+                                        new RemoteRepository.Builder(
+                                                DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
+                                                .setAuthentication(buildMavenAuthentication(credentials))
+                                                .build())
+                        .orElse(
+                                new RemoteRepository.Builder(DAML_REPO_ID, MAVEN_REPO_TYPE_DEFAULT, mavenRepoUrl)
+                                        .build());
+
+        ArtifactRequest artifactRequest =
+                new ArtifactRequest()
+                        .setArtifact(new DefaultArtifact(groupId, artifactId, extension, version))
+                        .setRepositories(singletonList(remoteRepository));
+
+        try {
+            RepositorySystem repositorySystem =
+                    MavenRepositorySystemUtils.newServiceLocator()
+                            .addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class)
+                            .addService(TransporterFactory.class, FileTransporterFactory.class)
+                            .addService(TransporterFactory.class, HttpTransporterFactory.class)
+                            .getService(RepositorySystem.class);
+
+            DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+            session.setLocalRepositoryManager(
+                    repositorySystem.newLocalRepositoryManager(
+                            session, new LocalRepository(localRepository.toString())));
+            ArtifactResult artifactResult = repositorySystem.resolveArtifact(session, artifactRequest);
+            return Optional.ofNullable(artifactResult.getArtifact().getFile());
+        } catch (ArtifactResolutionException e) {
+            throw new IllegalStateException(
+                    "Unable to download artifact " + groupId + ":" + artifactId + ":" + version, e);
+        }
+    }
+
+    private static Authentication buildMavenAuthentication(MavenCredentials credentials) {
+        return new AuthenticationBuilder()
+                .addUsername(credentials.getUserName())
+                .addPassword(credentials.getPassword())
+                .build();
+    }
+
+}

--- a/src/main/java/com/digitalasset/testing/junit4/Sandbox.java
+++ b/src/main/java/com/digitalasset/testing/junit4/Sandbox.java
@@ -9,6 +9,7 @@ package com.digitalasset.testing.junit4;
 import static com.digitalasset.testing.utils.PackageUtils.findPackage;
 import static com.digitalasset.testing.utils.Preconditions.require;
 import static com.digitalasset.testing.utils.SandboxUtils.isDamlRoot;
+import static com.google.common.io.Files.createTempDir;
 
 import com.daml.daml_lf_dev.DamlLf1;
 import com.daml.ledger.javaapi.data.Identifier;
@@ -19,19 +20,25 @@ import com.digitalasset.testing.ledger.SandboxManager;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.ManagedChannel;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
 import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Sandbox {
   private static final Duration DEFAULT_WAIT_TIMEOUT = Duration.ofSeconds(30);
   private static final Duration DEFAULT_OBSERVATION_TIMEOUT = Duration.ofSeconds(10);
   private static final String[] DEFAULT_PARTIES = new String[] {};
   private final SandboxManager sandboxManager;
+
+  private final Logger logger = LoggerFactory.getLogger(getClass().getCanonicalName());
 
   public static SandboxBuilder builder() {
     return new SandboxBuilder();
@@ -69,14 +76,18 @@ public class Sandbox {
   private final boolean useReset;
 
   public static class SandboxBuilder {
+    private final Logger logger = LoggerFactory.getLogger(getClass().getCanonicalName());
+
     private static final Path WORKING_DIRECTORY = Paths.get("").toAbsolutePath();
     private Optional<String> testModule = Optional.empty();
     private Optional<String> testStartScript = Optional.empty();
     private Duration sandboxWaitTimeout = DEFAULT_WAIT_TIMEOUT;
     private Duration observationTimeout = DEFAULT_OBSERVATION_TIMEOUT;
     private String[] parties = DEFAULT_PARTIES;
-    private Path damlRoot = WORKING_DIRECTORY;
-    private Path darPath;
+    private Path localDamlRoot = WORKING_DIRECTORY;
+    private Optional<Path> darPath = Optional.empty();
+    private Optional<MavenCoordinates> darMavenCoordinates = Optional.empty();
+    boolean downloadDamlYamlFromMaven;
     private boolean useWallclockTime = false;
     private boolean useReset = false;
     private BiConsumer<DamlLedgerClient, ManagedChannel> setupApplication = (t, u) -> {};
@@ -84,7 +95,12 @@ public class Sandbox {
     private Optional<LogLevel> logLevel = Optional.empty();
 
     public SandboxBuilder dar(Path darPath) {
-      this.darPath = darPath;
+      this.darPath = Optional.ofNullable(darPath);
+      return this;
+    }
+
+    public SandboxBuilder darMavenCoordinates(MavenCoordinates darMavenCoordinates) {
+      this.darMavenCoordinates = Optional.ofNullable(darMavenCoordinates);
       return this;
     }
 
@@ -149,21 +165,37 @@ public class Sandbox {
     }
 
     public SandboxBuilder damlRoot(Path damlRoot) {
-      this.damlRoot = damlRoot;
+      this.localDamlRoot = damlRoot;
       return this;
     }
 
     public Sandbox build() {
       validate();
 
+      final Path resolvedDarPath =
+          darPath.orElseGet(
+              () ->
+                  darMavenCoordinates
+                      .map(this::downloadDarFile)
+                      .orElseThrow(
+                          () ->
+                              new IllegalArgumentException(
+                                  "you must specify either a local path to a dar file or some maven coordinates")));
+
+      final Path damlRootPath =
+          darMavenCoordinates
+              .flatMap(MavenCoordinates::getYamlArtifact)
+              .map(s -> this.setupDamlRootWithYamlFromMaven(darMavenCoordinates.get()))
+              .orElse(localDamlRoot);
+
       return new Sandbox(
-          damlRoot,
+          damlRootPath,
           testModule,
           testStartScript,
           sandboxWaitTimeout,
           observationTimeout,
           parties,
-          darPath,
+          resolvedDarPath,
           setupApplication,
           useWallclockTime,
           useReset,
@@ -171,12 +203,41 @@ public class Sandbox {
           logLevel);
     }
 
+    private Path downloadDarFile(MavenCoordinates coordinates) {
+      logger.info("downloading dar file from maven repo: " + coordinates.getRepoUrl());
+      final Path path =
+          MavenDownloader.downloadDarFileFromMaven(coordinates, createTempDir())
+              .map(File::toPath)
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Unable to download dar file from specified maven repository"));
+      logger.info("dar file downloaded at path: " + path.toAbsolutePath().toString());
+      return path;
+    }
+
+    private Path setupDamlRootWithYamlFromMaven(MavenCoordinates coordinates) {
+      return MavenDownloader.downloadDamlYamlFileFromMaven(coordinates, createTempDir())
+          .map(File::getParentFile)
+          .map(File::toPath)
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "Unable to download dar file from specified maven repository"));
+    }
+
     private void validate() {
-      require(darPath != null, "DAR path cannot be null.");
+      require(
+          darPath != null && darPath.isPresent() || darMavenCoordinates.isPresent(),
+          "you must specify either a local path to a DAR file or coordinates that point to a DAR file in a maven repository");
+      require(
+          (darPath == null || !darPath.isPresent())
+              || (darMavenCoordinates == null || !darMavenCoordinates.isPresent()),
+          "you cannot specify both a local path to a DAR file and coordinates that point to a DAR file in a maven repository");
       require(setupApplication != null, "Application setup function cannot be null.");
       require(
-          isDamlRoot(damlRoot),
-          String.format("DAML root '%s' must contain a daml.yaml.", damlRoot));
+          isDamlRoot(localDamlRoot),
+          String.format("DAML root '%s' must contain a daml.yaml.", localDamlRoot));
     }
   }
 

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
@@ -25,20 +25,22 @@ public class SandboxIT {
   private static Sandbox sandbox =
       Sandbox.builder()
           .damlRoot(PINGPONG_PATH)
-          .darMavenCoordinates(MavenCoordinates.builder()
+          .darMavenCoordinates(
+              MavenCoordinates.builder()
                   .repoUrl("https://nexus.liquid-share.io/repository/liquidshare-maven")
                   .group("io.liquidshare.daml")
                   .darArtifact("liquidshare-daml")
                   .yamlArtifact("liquidshare-daml-manifest")
                   .version("0.28.0")
-                  .mavenCredentials(MavenCredentials.builder()
+                  .mavenCredentials(
+                      MavenCredentials.builder()
                           .userName("emil.kirschner")
                           .password("uAU@UHQJQcE8_uZmed!RfJrY_JB6K2MVL4zzQLE@@3hfxsqz")
                           .build())
                   .build())
           .ledgerId("sample-ledger")
           .logLevel(LogLevel.DEBUG) // implicitly test loglevel override
-              .sandboxWaitTimeout(Duration.of(1, ChronoUnit.MINUTES))
+          .sandboxWaitTimeout(Duration.of(1, ChronoUnit.MINUTES))
           .build();
 
   @ClassRule public static ExternalResource classRule = sandbox.getClassRule();

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
@@ -17,14 +17,28 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 public class SandboxIT {
 
   private static Sandbox sandbox =
       Sandbox.builder()
           .damlRoot(PINGPONG_PATH)
-          .dar(DAR_PATH)
+          .darMavenCoordinates(MavenCoordinates.builder()
+                  .repoUrl("https://nexus.liquid-share.io/repository/liquidshare-maven")
+                  .group("io.liquidshare.daml")
+                  .darArtifact("liquidshare-daml")
+                  .yamlArtifact("liquidshare-daml-manifest")
+                  .version("0.28.0")
+                  .mavenCredentials(MavenCredentials.builder()
+                          .userName("emil.kirschner")
+                          .password("uAU@UHQJQcE8_uZmed!RfJrY_JB6K2MVL4zzQLE@@3hfxsqz")
+                          .build())
+                  .build())
           .ledgerId("sample-ledger")
           .logLevel(LogLevel.DEBUG) // implicitly test loglevel override
+              .sandboxWaitTimeout(Duration.of(1, ChronoUnit.MINUTES))
           .build();
 
   @ClassRule public static ExternalResource classRule = sandbox.getClassRule();

--- a/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
+++ b/src/test/java/com/digitalasset/testing/junit4/SandboxIT.java
@@ -23,25 +23,13 @@ import java.time.temporal.ChronoUnit;
 public class SandboxIT {
 
   private static Sandbox sandbox =
-      Sandbox.builder()
-          .damlRoot(PINGPONG_PATH)
-          .darMavenCoordinates(
-              MavenCoordinates.builder()
-                  .repoUrl("https://nexus.liquid-share.io/repository/liquidshare-maven")
-                  .group("io.liquidshare.daml")
-                  .darArtifact("liquidshare-daml")
-                  .yamlArtifact("liquidshare-daml-manifest")
-                  .version("0.28.0")
-                  .mavenCredentials(
-                      MavenCredentials.builder()
-                          .userName("emil.kirschner")
-                          .password("uAU@UHQJQcE8_uZmed!RfJrY_JB6K2MVL4zzQLE@@3hfxsqz")
-                          .build())
-                  .build())
-          .ledgerId("sample-ledger")
-          .logLevel(LogLevel.DEBUG) // implicitly test loglevel override
-          .sandboxWaitTimeout(Duration.of(1, ChronoUnit.MINUTES))
-          .build();
+          Sandbox.builder()
+                  .damlRoot(PINGPONG_PATH)
+                  .dar(DAR_PATH)
+                  .ledgerId("sample-ledger")
+                  .logLevel(LogLevel.DEBUG) // implicitly test loglevel override
+                  .build();
+
 
   @ClassRule public static ExternalResource classRule = sandbox.getClassRule();
 


### PR DESCRIPTION
When working on projects that use continuous integration and continuous delivery methodologies, it is important to automate as many tasks as possible. 

When testing  java code that interacts with the DAML ledger, the task of constantly syncing local test DAR files with the java bindings version used by the project is a tedious and error prone task, especialy in rapidely changing environments.

Using this proposed feature, the JUnit rule can be configured to automatically download and use DAR files from maven repositories. The version of the artifacts to be downloaded can be enforced to match the one of the java bindings the project uses by having the build system push the bindings version to test code via environment or JVM arguments. 

This way all one has to do si to specify the new version of the bindings in build dependencies, and the test code will automatically download the matching DAR file.  Of course the prerequisite of this is that the DAML CI pipeline myst publish the DAR file, the bindings jar and the daml.yaml file to a Maven repo under the same version.

This feature is being successfully used at LiquidShare on a daily basis by a team of 4 java backend engineers for more than a month.