### PR TITLE
DEL-8338: fix case when value is given as null or none

### DIFF
--- a/src/main/scala/com/digitalasset/testing/ast/Ast.scala
+++ b/src/main/scala/com/digitalasset/testing/ast/Ast.scala
@@ -20,10 +20,14 @@ object Ast {
   case object Null extends Ast
 
   object NullaryConstructor {
-    def unapply(ast: Ast): Option[String] = condOpt(ast) { case Constructor((key, Ast.Null)) => key }
+    def unapply(ast: Ast): Option[String] = condOpt(ast) {
+      case Constructor((key, Ast.Null)) => key
+    }
   }
 
   object Constructor {
-    def unapply(ast: Ast): Option[(String, Ast)] = condOpt(ast) { case Map(map) if map.size == 1 => map.head }
+    def unapply(ast: Ast): Option[(String, Ast)] = condOpt(ast) {
+      case Map(map) if map.size == 1 => map.head
+    }
   }
 }

--- a/src/main/scala/com/digitalasset/testing/ast/Ast.scala
+++ b/src/main/scala/com/digitalasset/testing/ast/Ast.scala
@@ -6,6 +6,8 @@
 
 package com.digitalasset.testing.ast
 
+import PartialFunction._
+
 /**
   * ADTs representing typical hierarchical structure. This is the most generic common representation for YAML, JSON, and
   * other type-less hierarchical structures. DAML contracts can be represented using just these constructs.
@@ -16,4 +18,12 @@ object Ast {
   case class Map(value: collection.Map[String, Ast]) extends Ast
   case class Value(value: String) extends Ast
   case object Null extends Ast
+
+  object NullaryConstructor {
+    def unapply(ast: Ast): Option[String] = condOpt(ast) { case Constructor((key, Ast.Null)) => key }
+  }
+
+  object Constructor {
+    def unapply(ast: Ast): Option[(String, Ast)] = condOpt(ast) { case Map(map) if map.size == 1 => map.head }
+  }
 }

--- a/src/main/scala/com/digitalasset/testing/ast/Ast.scala
+++ b/src/main/scala/com/digitalasset/testing/ast/Ast.scala
@@ -19,12 +19,6 @@ object Ast {
   case class Value(value: String) extends Ast
   case object Null extends Ast
 
-  object NullaryConstructor {
-    def unapply(ast: Ast): Option[String] = condOpt(ast) {
-      case Constructor((key, Ast.Null)) => key
-    }
-  }
-
   object Constructor {
     def unapply(ast: Ast): Option[(String, Ast)] = condOpt(ast) {
       case Map(map) if map.size == 1 => map.head

--- a/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
+++ b/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
@@ -79,6 +79,18 @@ package object ledger {
       case (Ast.Null, Ast.Null) =>
         Same()
 
+      case (Ast.Null, _) => 
+        Diff(s"$path: Expected to be null, but actual value is: $actual")
+
+      case (_, Ast.Null) => 
+        Diff(s"$path: Value is null, but was expected to be: $expected")
+
+      case (Ast.Value("None"), _) =>
+        Diff(s"$path: Expected to be none, but actual value is: $actual")
+
+      case (_, Ast.Value("None")) =>
+        Diff(s"$path: Value is none, but was expected to be: $expected")
+
       case _ =>
         Error(s"$path: Unexpected or unsupported case: $expected, $actual")
     }

--- a/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
+++ b/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
@@ -38,31 +38,6 @@ package object ledger {
     (expected, actual) match {
       case (Ast.Value(IgnoreRegex()), _) => Same()
 
-      case (Ast.Map(exp), Ast.Map(act))
-          if exp.size == act.size && exp.keySet == act.keySet =>
-        (exp.toList.sortBy(_._1) zip act.toList.sortBy(_._1)).map {
-          case ((expK, expV), (_, actV)) =>
-            compareAst(expV, actV, s"$path.$expK")
-        }.suml
-
-      case (Ast.Value(constructor), Ast.Map(kv))
-          if kv.size == 1 && kv.values.head == Ast.Null =>
-        compareValues(constructor, kv.keys.head, s"$path.$constructor")
-
-      case (Ast.Map(expMap), Ast.Map(actMap)) =>
-        val expectedKeys = expMap.keySet diff actMap.keySet
-        val unexpectedKeys = actMap.keySet diff expMap.keySet
-        val expected =
-          if (expectedKeys.isEmpty) ""
-          else
-            expectedKeys.mkString(" Expected keys which where not present: [",
-                                  ", ",
-                                  "].")
-        val unexpected =
-          if (unexpectedKeys.isEmpty) ""
-          else unexpectedKeys.mkString(" Unexpected keys: [", ", ", "].")
-        Diff(s"$path: Records have different key sets.$expected$unexpected")
-
       case (Ast.Seq(exp), Ast.Seq(act)) if exp.size == act.size =>
         (exp zip act).zipWithIndex
           .map { case ((e, a), ix) => compareAst(e, a, s"$path[$ix]") }
@@ -73,25 +48,56 @@ package object ledger {
         Diff(
           s"$path: Expected list of size ${exp.size}, but got list of size ${act.size}")
 
+      case (Ast.Value(expectedCtor), Ast.Constructor(actualCtor, actualParams)) =>
+        compareCtor(expectedCtor, Ast.Null, actualCtor, actualParams, path)
+
+      case (Ast.Constructor(expectedCtor, expectedParams), Ast.Value(actualCtor)) =>
+        compareCtor(expectedCtor, expectedParams, actualCtor, Ast.Null, path)
+
+      case (Ast.Constructor(expectedCtor, expectedParams), Ast.Constructor(actualCtor, actualParams)) =>
+        compareCtor(expectedCtor, expectedParams, actualCtor, actualParams, path)
+
+      case (Ast.Map(expMap), Ast.Map(actMap)) =>
+        (expMap.keySet ++ actMap.keySet).toList.sorted.foldMap { key =>
+          (expMap.get(key), actMap.get(key)) match {
+            case (Some(expV), Some(actV)) => compareAst(expV, actV, s"$path.$key")
+            case (None, Some(actV))       => compareAst(Ast.Null, actV, s"$path.$key")
+            case (Some(expV), None)       => compareAst(expV, Ast.Null, s"$path.$key")
+            case (None, None)             => Error("Internal bug")
+          }
+        }
+
       case (Ast.Value(exp), Ast.Value(act)) =>
         compareValues(exp, act, path)
 
       case (Ast.Null, Ast.Null) =>
         Same()
 
-      case (Ast.Null, _) => 
-        Diff(s"$path: Expected to be null, but actual value is: $actual")
+      case (Ast.Null, Ast.Value(act)) =>
+        Diff(s"$path: Value [$act] not expected")
 
-      case (_, Ast.Null) => 
-        Diff(s"$path: Value is null, but was expected to be: $expected")
+      case (Ast.Value(exp), Ast.Null) =>
+        Diff(s"$path: Value [$exp] expected, but it is missing")
 
-      case (Ast.Value("None"), _) =>
-        Diff(s"$path: Expected to be none, but actual value is: $actual")
+      case (Ast.Null, _) =>
+        Diff(s"$path: Value [$actual] not expected")
 
-      case (_, Ast.Value("None")) =>
-        Diff(s"$path: Value is none, but was expected to be: $expected")
+      case (_, Ast.Null) =>
+        Diff(s"$path: Value [$expected] expected, but it is missing")
 
       case _ =>
-        Error(s"$path: Unexpected or unsupported case: $expected, $actual")
+        Error(s"$path: Unexpected or unsupported case: [$expected], [$actual]")
+    }
+
+  private def compareCtor(expectedCtor: String,
+                          expectedParams: Ast,
+                          actualCtor: String,
+                          actualParams: Ast,
+                          path: String): ComparisonResult =
+    (expectedCtor, expectedParams, actualCtor, actualParams) match {
+      case (e, ep, a, ap) if e != a =>
+        Diff(
+          s"$path: Actual constructor / singleton map $a => $ap doesn't match expected constructor / singleton map $e => $ep")
+      case (c, e, _, a) => compareAst(e, a, s"$path.$c")
     }
 }

--- a/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
+++ b/src/main/scala/com/digitalasset/testing/comparator/ledger/package.scala
@@ -48,22 +48,30 @@ package object ledger {
         Diff(
           s"$path: Expected list of size ${exp.size}, but got list of size ${act.size}")
 
-      case (Ast.Value(expectedCtor), Ast.Constructor(actualCtor, actualParams)) =>
+      case (Ast.Value(expectedCtor),
+            Ast.Constructor(actualCtor, actualParams)) =>
         compareCtor(expectedCtor, Ast.Null, actualCtor, actualParams, path)
 
-      case (Ast.Constructor(expectedCtor, expectedParams), Ast.Value(actualCtor)) =>
+      case (Ast.Constructor(expectedCtor, expectedParams),
+            Ast.Value(actualCtor)) =>
         compareCtor(expectedCtor, expectedParams, actualCtor, Ast.Null, path)
 
-      case (Ast.Constructor(expectedCtor, expectedParams), Ast.Constructor(actualCtor, actualParams)) =>
-        compareCtor(expectedCtor, expectedParams, actualCtor, actualParams, path)
+      case (Ast.Constructor(expectedCtor, expectedParams),
+            Ast.Constructor(actualCtor, actualParams)) =>
+        compareCtor(expectedCtor,
+                    expectedParams,
+                    actualCtor,
+                    actualParams,
+                    path)
 
       case (Ast.Map(expMap), Ast.Map(actMap)) =>
         (expMap.keySet ++ actMap.keySet).toList.sorted.foldMap { key =>
           (expMap.get(key), actMap.get(key)) match {
-            case (Some(expV), Some(actV)) => compareAst(expV, actV, s"$path.$key")
-            case (None, Some(actV))       => compareAst(Ast.Null, actV, s"$path.$key")
-            case (Some(expV), None)       => compareAst(expV, Ast.Null, s"$path.$key")
-            case (None, None)             => Error("Internal bug")
+            case (Some(expV), Some(actV)) =>
+              compareAst(expV, actV, s"$path.$key")
+            case (None, Some(actV)) => compareAst(Ast.Null, actV, s"$path.$key")
+            case (Some(expV), None) => compareAst(expV, Ast.Null, s"$path.$key")
+            case (None, None)       => Error("Internal bug")
           }
         }
 


### PR DESCRIPTION
Currently if only one of the expected or actual values are nulls or nones the case falls back to the catch-all case, and will err out.

This means func-tests will only show the first of such fields as being incorrect, and they need to be rerun and fixed one-by-one.

Please see https://github.com/DACH-NY/func-test-framework/pull/152 for a discussion on this topic.