### PR TITLE
distinguish OS for DamlScriptRunner 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Set jps path 
           command: |
-            sudo ln -s ${JAVA_HOME}/bin/jps /usr/bin/jps
+            sudo ln -fs ${JAVA_HOME}/bin/jps /usr/bin/jps
       - run:
           command: |
             sbt verify packageAll

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Set jps path 
           command: |
-            sudo ln -s ${JAVA_HOME}/bin/jps /usr/bin/jps
+            sudo ln -fs ${JAVA_HOME}/bin/jps /usr/bin/jps
       - run:
           command: |
             if git show --name-only HEAD | grep version.sbt; then

--- a/src/main/java/com/daml/extensions/testing/ledger/DamlScriptRunner.java
+++ b/src/main/java/com/daml/extensions/testing/ledger/DamlScriptRunner.java
@@ -13,6 +13,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+
+import com.daml.extensions.testing.utils.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,10 +92,12 @@ public class DamlScriptRunner {
 
     private ProcessBuilder command() {
       String sandboxHost = "localhost";
+      String damlCommand = OS.isWindows()? "daml.cmd" : "daml";
+
       return new ProcessBuilder()
           .directory(damlRoot.toFile())
           .command(
-              "daml",
+              damlCommand,
               "script",
               "--dar",
               darPath.toString(),

--- a/src/main/java/com/daml/extensions/testing/ledger/DamlScriptRunner.java
+++ b/src/main/java/com/daml/extensions/testing/ledger/DamlScriptRunner.java
@@ -6,6 +6,7 @@
 
 package com.daml.extensions.testing.ledger;
 
+import static com.daml.extensions.testing.utils.OS.damlCommand;
 import static com.daml.extensions.testing.utils.Preconditions.require;
 import static com.daml.extensions.testing.utils.SandboxUtils.isDamlRoot;
 
@@ -14,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import com.daml.extensions.testing.utils.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,12 +92,11 @@ public class DamlScriptRunner {
 
     private ProcessBuilder command() {
       String sandboxHost = "localhost";
-      String damlCommand = OS.isWindows()? "daml.cmd" : "daml";
 
       return new ProcessBuilder()
           .directory(damlRoot.toFile())
           .command(
-              damlCommand,
+              damlCommand(),
               "script",
               "--dar",
               darPath.toString(),

--- a/src/main/java/com/daml/extensions/testing/utils/OS.java
+++ b/src/main/java/com/daml/extensions/testing/utils/OS.java
@@ -10,4 +10,8 @@ public class OS {
   public static boolean isWindows() {
     return System.getProperty("os.name").contains("indows");
   }
+
+  public static String damlCommand() {
+    return isWindows() ? "daml.cmd" : "daml";
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version := "0.2.5"
+version := "0.2.6"
 versionScheme := Some("semver-spec")


### PR DESCRIPTION
We noticed that on Windows DamlScriptRunner did not work with default Daml SDK installation and the PR includes a fix for this issue.